### PR TITLE
htmltools v0.4.0 test updates

### DIFF
--- a/tests/testthat/test_download_file.R
+++ b/tests/testthat/test_download_file.R
@@ -5,7 +5,7 @@ test_that("downloadFileButton", {
     result <- downloadFileButton(id = "myid", downloadtypes = c("csv"), hovertext = "myhovertext")
 
     expect_equal(result$name, "span")
-    expect_equal(result$attribs, list())
+    expect_type(result$attribs, "list")
 
     result.children <- result$children
     expect_equal(length(result.children), 2)
@@ -17,7 +17,7 @@ test_that("downloadFileButton", {
     expect_equal(result.children[[1]]$attribs$download, NA)
 
     expect_equal(result.children[[2]]$name, "script")
-    expect_equal(result.children[[2]]$attribs, list())
+    expect_type(result.children[[2]]$attribs, "list")
     expect_equal(length(result.children[[2]]$children), 1)
     expect_equal(result$children[[2]]$children[[1]], shiny::HTML("$(document).ready(function() {setTimeout(function() {shinyBS.addTooltip('myid-csv', 'tooltip', {'placement': 'top', 'trigger': 'hover', 'title': 'myhovertext'})}, 500)});"))
 })
@@ -54,7 +54,7 @@ test_that("downloadFileButton multiple types", {
     expect_equal(result.subsubchilds[[1]][[1]], list())
 
     expect_equal(result.subsubchilds[[1]][[2]]$name, "li")
-    expect_equal(result.subsubchilds[[1]][[2]]$attribs, list())
+    expect_type(result.subsubchilds[[1]][[2]]$attribs, "list")
     result.subsubsubchilds <- result.subsubchilds[[1]][[2]]$children
     expect_equal(length(result.subsubsubchilds), 1)
 
@@ -67,7 +67,7 @@ test_that("downloadFileButton multiple types", {
     expect_equal(result.subsubsubchilds[[1]]$children[[1]], "csv")
 
     expect_equal(result.children[[3]]$name, "script")
-    expect_equal(result.children[[3]]$attribs, list())
+    expect_type(result.children[[3]]$attribs, "list")
     expect_equal(length(result.children[[3]]$children), 1)
     expect_equal(result$children[[3]]$children[[1]], shiny::HTML("$(document).ready(function() {setTimeout(function() {shinyBS.addTooltip('myid-downloadFileList', 'tooltip', {'placement': 'top', 'trigger': 'hover', 'title': 'myhovertext'})}, 500)});"))
 })

--- a/tests/testthat/test_downloadable_plot.R
+++ b/tests/testthat/test_downloadable_plot.R
@@ -4,7 +4,7 @@ check_common_downloadablePlotUI_properties <- function(result.children) {
     expect_equal(length(result.children), 1)
 
     expect_equal(result.children[[1]]$name, "span")
-    expect_equal(result.children[[1]]$attribs, list())
+    expect_type(result.children[[1]]$attribs, "list")
 
     result.subchildren <- result.children[[1]]$children
     expect_equal(length(result.subchildren), 2)
@@ -22,7 +22,7 @@ check_common_downloadablePlotUI_properties <- function(result.children) {
     expect_equal(result.subsubchildren[[2]], NULL)
 
     expect_equal(result.subchildren[[2]]$name, "script")
-    expect_equal(result.subchildren[[2]]$attribs, list())
+    expect_type(result.subchildren[[2]]$attribs, "list")
 
     result.subsubchildren <- result.subchildren[[2]]$children
     expect_equal(length(result.subsubchildren), 1)


### PR DESCRIPTION
Next version of `htmltools` (0.4.0) is producing some named list objects in the `attribs`.

During `revdepcheck`, I ran into errors on the lines below.  I updated the checks and have tried to keep the spirit of original test.

We are planning on releasing to CRAN here shortly.  If this change could be posted to CRAN soon, that would be great! (If not, please let us know. 😃 )

Thank you for your help!
\- Shiny Team