### PR TITLE
Check reactive class value using `shiny::is.reactive()`

### DIFF
--- a/tests/testthat/test_ui_misc_functions.R
+++ b/tests/testthat/test_ui_misc_functions.R
@@ -34,7 +34,7 @@ test_that("fw_get_user_log", {
 
 test_that("setup_logging", {
     result <- shiny::isolate(.setup_logging(NULL, periscope:::fw_get_user_log()))
-    expect_true(inherits(result, "reactive"))
+    expect_true(shiny::is.reactive(result))
 })
 
 test_that("setup_logging existing log", {
@@ -42,7 +42,7 @@ test_that("setup_logging existing log", {
     file.create(paste0(paste(log_directory, logger$name, sep = .Platform$file.sep), ".log"))
 
     result <- shiny::isolate(.setup_logging(NULL,logger))
-    expect_true(inherits(result, "reactive"))
+    expect_true(shiny::is.reactive(result))
 })
 
 test_that("fw_reset_app_options", {

--- a/tests/testthat/test_ui_misc_functions.R
+++ b/tests/testthat/test_ui_misc_functions.R
@@ -34,7 +34,7 @@ test_that("fw_get_user_log", {
 
 test_that("setup_logging", {
     result <- shiny::isolate(.setup_logging(NULL, periscope:::fw_get_user_log()))
-    expect_equal(class(result), c("reactiveExpr", "reactive"))
+    expect_true(inherits(result, "reactive"))
 })
 
 test_that("setup_logging existing log", {
@@ -42,7 +42,7 @@ test_that("setup_logging existing log", {
     file.create(paste0(paste(log_directory, logger$name, sep = .Platform$file.sep), ".log"))
 
     result <- shiny::isolate(.setup_logging(NULL,logger))
-    expect_equal(class(result), c("reactiveExpr", "reactive"))
+    expect_true(inherits(result, "reactive"))
 })
 
 test_that("fw_reset_app_options", {


### PR DESCRIPTION
The `shiny` team has added an additional class to `reactive()` objects.

I believe this change still keeps the intent while allowing `shiny` some flexibility in the code.

------------

We are aiming to release the week of May 25th. We hope this does not disrupt your package on CRAN.  

Thank you!
\- Barret