### PR TITLE
Update UI test expectations to accommodate shiny 1.6

### DIFF
--- a/tests/testthat/test_download_file.R
+++ b/tests/testthat/test_download_file.R
@@ -1,5 +1,7 @@
 context("periscope - download file")
 
+skip_on_cran()
+
 test_that("downloadFileButton", {
 
     result <- downloadFileButton(id = "myid", downloadtypes = c("csv"), hovertext = "myhovertext")

--- a/tests/testthat/test_downloadable_plot.R
+++ b/tests/testthat/test_downloadable_plot.R
@@ -1,5 +1,7 @@
 context("periscope - downloadablePlot")
 
+skip_on_cran()
+
 check_common_downloadablePlotUI_properties <- function(result.children) {
     expect_equal(length(result.children), 1)
 
@@ -16,7 +18,7 @@ check_common_downloadablePlotUI_properties <- function(result.children) {
     expect_equal(length(result.subsubchildren), 2)
 
     expect_equal(result.subsubchildren[[1]]$name, "i")
-    expect_equal(result.subsubchildren[[1]]$attribs, list(class = "fa fa-download"))
+    expect_equal(result.subsubchildren[[1]]$attribs$class, "fa fa-download")
     expect_equal(result.subsubchildren[[1]]$children, list())
 
     expect_equal(result.subsubchildren[[2]], NULL)
@@ -47,7 +49,8 @@ test_that("downloadablePlotUI btn_overlap=true btn_halign=left btn_valign=bottom
     expect_equal(result[[1]]$name, "div")
     expect_equal(result[[1]]$attribs$id, "myid-dplotOutputID")
     expect_equal(result[[1]]$attribs$class, "shiny-plot-output")
-    expect_equal(result[[1]]$attribs$style, "width: 80% ; height: 300px")
+    expect_match(result[[1]]$attribs$style, "width:\\s*80%")
+    expect_match(result[[1]]$attribs$style, "height:\\s*300px")
 
     expect_equal(result[[2]]$name, "span")
 
@@ -82,7 +85,8 @@ test_that("downloadablePlotUI btn_overlap=false btn_halign=center btn_valign=top
     expect_equal(result[[2]]$name, "div")
     expect_equal(result[[2]]$attribs$id, "myid-dplotOutputID")
     expect_equal(result[[2]]$attribs$class, "shiny-plot-output")
-    expect_equal(result[[2]]$attribs$style, "width: 80% ; height: 300px")
+    expect_match(result[[2]]$attribs$style, "width:\\s*80%")
+    expect_match(result[[2]]$attribs$style, "height:\\s*300px")
 
     result.children <- result[[2]]$children
     expect_equal(result.children, list())

--- a/tests/testthat/test_downloadable_table.R
+++ b/tests/testthat/test_downloadable_table.R
@@ -1,5 +1,7 @@
 context("periscope - downloadable table")
 
+skip_on_cran()
+
 test_that("downloadableTable", {
 
     result <- downloadableTableUI(id = "myid", downloadtypes = c("csv"), hovertext = "myHoverText")

--- a/tests/testthat/test_ui_functions.R
+++ b/tests/testthat/test_ui_functions.R
@@ -1,5 +1,7 @@
 context("periscope - UI functionality")
 
+skip_on_cran()
+
 test_that("fw_create_header", {
     result <- periscope:::fw_create_header()
     expect_equal(result$name, "header")
@@ -152,21 +154,21 @@ check_body_result <- function(result, logging = TRUE) {
         expect_equal(length(result.subchilds[[4]]), 3)
 
         expect_equal(result.subchilds[[4]]$name, "div")
-        expect_equal(result.subchilds[[4]]$attribs, list(class = "col-sm-12"))
+        expect_equal(result.subchilds[[4]]$attribs$class, "col-sm-12")
         result.subsubchilds <- result.subchilds[[4]]$children
 
         expect_equal(result.subsubchilds[[1]]$name, "div")
-        expect_equal(result.subsubchilds[[1]]$attribs, list(class = "box collapsed-box"))
+        expect_equal(result.subsubchilds[[1]]$attribs$class, "box collapsed-box")
 
         result.subsubsubchilds <- result.subsubchilds[[1]]$children
         expect_equal(length(result.subsubsubchilds), 3)
         expect_equal(result.subsubsubchilds[[1]]$name, "div")
-        expect_equal(result.subsubsubchilds[[1]]$attribs, list(class = "box-header"))
+        expect_equal(result.subsubsubchilds[[1]]$attribs$class, "box-header")
 
         result.subsubsubsubchilds <- result.subsubsubchilds[[1]]$children
         expect_equal(length(result.subsubsubsubchilds), 2)
         expect_equal(result.subsubsubsubchilds[[1]]$name, "h3")
-        expect_equal(result.subsubsubsubchilds[[1]]$attribs, list(class = "box-title"))
+        expect_equal(result.subsubsubsubchilds[[1]]$attribs$class, "box-title")
 
         result.subsubsubsubsubchilds <- result.subsubsubsubchilds[[1]]$children
         expect_equal(result.subsubsubsubsubchilds[[1]], "User Action Log")
@@ -177,7 +179,7 @@ check_body_result <- function(result, logging = TRUE) {
         expect_equal(length(result.subsubsubsubsubchilds[[1]]$children), 1)
 
         expect_equal(result.subsubsubsubsubchilds[[1]]$children[[1]]$name, "i")
-        expect_equal(result.subsubsubsubsubchilds[[1]]$children[[1]]$attribs, list(class = "fa fa-plus"))
+        expect_equal(result.subsubsubsubsubchilds[[1]]$children[[1]]$attribs$class, "fa fa-plus")
         expect_equal(result.subsubsubsubsubchilds[[1]]$children[[1]]$children, list())
     } else {
         expect_equal(result.subchilds[[2]], NULL)
@@ -360,7 +362,7 @@ test_that("fw_create_right_sidebar", {
     expect_equal(length(result2.1.2.children[[2]]$children), 2)
     
     expect_equal(result2.1.2.children[[2]]$children[[1]]$name, "label")
-    expect_equal(result2.1.2.children[[2]]$children[[1]]$attribs, list(class = "control-label", `for` = "id"))
+    expect_equal(result2.1.2.children[[2]]$children[[1]]$attribs$class, "control-label")
     
     expect_equal(result2.1.2.children[[2]]$children[[2]]$name, "div")
     expect_equal(length(result2.1.2.children[[2]]$children[[2]]$children), 2)


### PR DESCRIPTION
In the next version of shiny (which we plan on submitting to CRAN in a week or so), we've made several changes to HTML/CSS markup that cause your unit tests to fail (in non-meaningful ways), and so we ask you to submit a new version of cytomapper to CRAN as soon as possible to address this issue.

This PR fixes the issue by updating your test expectations to work with shiny 1.6 and also adds `skip_on_cran()` to skip tests that make particularly strong assumptions about the HTML/CSS that shiny generates. This will make it so shiny can continue to make HTML/CSS changes as needed without requiring periscope to send updates to CRAN (you can still monitor the tests locally and/or on a CI service like Github Actions or Travis CI).

Let me know if you have any questions and please send a new version of periscope to CRAN with these updates to your tests as soon as possible.